### PR TITLE
Update qualities.xml

### DIFF
--- a/Chummer/data/qualities.xml
+++ b/Chummer/data/qualities.xml
@@ -10610,6 +10610,12 @@
           <quality>Infected: Fomoraig</quality>
           <quality>Infected: Gnawer</quality>
           <quality>Infected: Mutaqua</quality>
+          <quality>Infected: Ghoul (Dwarf)</quality>
+          <quality>Infected: Ghoul (Elf)</quality>
+          <quality>Infected: Ghoul (Human)</quality>
+          <quality>Infected: Ghoul (Ork)</quality>
+          <quality>Infected: Ghoul (Sasquatch)</quality>
+          <quality>Infected: Ghoul (Troll)</quality>
         </oneof>
       </required>
       <source>RF</source>
@@ -10838,6 +10844,12 @@
           <quality>Infected: Sukuyan (Human)</quality>
           <quality>Infected: Sukuyan (Non-Human)</quality>
           <quality>Infected: Wendigo</quality>
+          <quality>Infected: Ghoul (Dwarf)</quality>
+          <quality>Infected: Ghoul (Elf)</quality>
+          <quality>Infected: Ghoul (Human)</quality>
+          <quality>Infected: Ghoul (Ork)</quality>
+          <quality>Infected: Ghoul (Sasquatch)</quality>
+          <quality>Infected: Ghoul (Troll)</quality>
         </oneof>
       </required>
       <source>RF</source>
@@ -10866,6 +10878,12 @@
           <quality>Infected: Sukuyan (Human)</quality>
           <quality>Infected: Sukuyan (Non-Human)</quality>
           <quality>Infected: Wendigo</quality>
+          <quality>Infected: Ghoul (Dwarf)</quality>
+          <quality>Infected: Ghoul (Elf)</quality>
+          <quality>Infected: Ghoul (Human)</quality>
+          <quality>Infected: Ghoul (Ork)</quality>
+          <quality>Infected: Ghoul (Sasquatch)</quality>
+          <quality>Infected: Ghoul (Troll)</quality>
         </oneof>
       </required>
       <source>RF</source>


### PR DESCRIPTION
Allowed ghouls to take the infected optional powers Armor, Immunity (pathogens), and Immunity (toxins), as per Dark Terrors' updated optional power list. I think I tried to pass this fix up the chain and it didn't take? Someone tell me if I'm spamming something and didn't notice.